### PR TITLE
feat: Add BleManager and update to new NimBLE architecture

### DIFF
--- a/src/BleKeyboard.cpp
+++ b/src/BleKeyboard.cpp
@@ -5,7 +5,6 @@
 #include <NimBLEUtils.h>
 #include <NimBLEHIDDevice.h>
 #include "HIDTypes.h"
-#include <driver/adc.h>
 #include "sdkconfig.h"
 #include "layouts/KeyboardLayout.h"
 


### PR DESCRIPTION
This commit introduces a `BleManager` class to manage the BLE stack and HID devices.

- Adds a `BleManager` class responsible for initializing the NimBLE stack.
- Refactors the old `BleHid` class into a new `BleKeyboard` class, which is now a self-contained HID keyboard implementation based on the user's provided code.
- Introduces a `BleHid` adapter class that implements the `HIDInterface` and wraps a `BleKeyboard` object. This maintains compatibility with existing examples.
- Updates all BLE examples (`DuckyScript_BLE`, `Mouse_BLE`, `RestartKeyboard`) to use the new `BleManager`.
- Adds a new example `RestartKeyboard` to demonstrate how to start, stop, and restart the BLE keyboard at runtime.
- Updates the `BleMouse` class to work with the new architecture, where the BLE stack is managed externally, and fixes compilation errors related to the new NimBLE API.
- Updates `library.json` to include the new files and the new `h2zero/NimBLE-Arduino` dependency version.
- Removes non-NimBLE code to make the library NimBLE-only.
- Fixes key definitions to use the central `common/keys.h` file.
- Adds `pressRaw` and `releaseRaw` methods to `BleKeyboard` for handling raw keycodes.
- Adds keyboard layout support back to `BleKeyboard`.
- Fixes a typo in a header include in `BleKeyboard.cpp`.
- Fixes an issue with dropped characters by calling `releaseAll()` in the `BleKeyboard` constructor and in the `write` method.
- Updates `README.md` to reflect the new `BleManager` architecture.
- Adds a `LICENSE` file (MIT).
- Fixes a BLE authentication issue by waiting for pairing to complete before sending data.
- Removes an unused include of a deprecated ADC driver to resolve a compilation warning.