### PR TITLE
Fix BLE keyboard reconnection issue

### DIFF
--- a/include/BleKeyboard.h
+++ b/include/BleKeyboard.h
@@ -30,7 +30,7 @@ private:
   std::string        deviceName;
   std::string        deviceManufacturer;
   uint8_t            batteryLevel;
-  bool               connected = false;
+  volatile bool      connected = false;
   uint32_t           _delay_ms = 7;
   const uint8_t*     _asciimap;
   void delay_ms(uint64_t ms);
@@ -70,7 +70,7 @@ protected:
   virtual void onStarted(NimBLEServer *pServer) { };
   void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) override;
   void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
-  void onAuthenticationComplete(ble_gap_conn_desc* desc);
+  void onAuthenticationComplete(NimBLEConnInfo& connInfo) override;
   void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) override;
 };
 

--- a/src/BleKeyboard.cpp
+++ b/src/BleKeyboard.cpp
@@ -406,15 +406,16 @@ void BleKeyboard::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, 
   ESP_LOGI(LOG_TAG, "Client disconnected");
 }
 
-void BleKeyboard::onAuthenticationComplete(ble_gap_conn_desc* desc)
+void BleKeyboard::onAuthenticationComplete(NimBLEConnInfo& connInfo)
 {
-    if(!desc->sec_state.encrypted) {
-        NimBLEDevice::getServer()->disconnect(desc->conn_handle);
-        ESP_LOGE(LOG_TAG, "Encrypt connection failed");
+    if(!connInfo.isEncrypted()) {
+        // This shouldn't happen, but just in case.
+        NimBLEDevice::getServer()->disconnect(connInfo.getConnHandle());
+        ESP_LOGE(LOG_TAG, "Authentication complete but connection not encrypted");
         return;
     }
 
-    ESP_LOGI(LOG_TAG, "Paired successfully");
+    ESP_LOGI(LOG_TAG, "Authentication complete");
     this->connected = true;
 }
 


### PR DESCRIPTION
On subsequent connections of a paired BLE keyboard, the `onAuthenticationComplete` callback was not being correctly handled, preventing the connection flag from being set and causing the keyboard to be unresponsive.

This change refactors the authentication handling to correctly use the `NimBLEServerCallbacks` virtual method for `onAuthenticationComplete`. This ensures that the callback is invoked by the NimBLE stack for both initial pairing and subsequent reconnections of bonded devices.

The `connected` flag is also marked as `volatile` to ensure correct memory visibility between the BLE task and the main application task.

This resolves the issue where the keyboard would not work after reconnecting.